### PR TITLE
Fixed create push notification with external_id

### DIFF
--- a/models/PlayerNotificationTargetIncludeAliases.ts
+++ b/models/PlayerNotificationTargetIncludeAliases.ts
@@ -10,6 +10,8 @@ import { HttpFile } from '../http/http';
 
 export class PlayerNotificationTargetIncludeAliases {
     'alias_label'?: Array<string>;
+    'external_id'?: Array<string>;
+    'onesignal_id'?: Array<string>;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -19,7 +21,20 @@ export class PlayerNotificationTargetIncludeAliases {
             "baseName": "alias_label",
             "type": "Array<string>",
             "format": ""
-        }    ];
+        },
+        {
+            "name": "external_id",
+            "baseName": "external_id",
+            "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "onesignal_id",
+            "baseName": "onesignal_id",
+            "type": "Array<string>",
+            "format": ""
+        }
+    ];
 
     static getAttributeTypeMap() {
         return PlayerNotificationTargetIncludeAliases.attributeTypeMap;


### PR DESCRIPTION
# Description
 - Fixed create push notification with external_id, onesignal_id

## Details
- createNotification function is not send include_aliases object with extearnal_id values 

### Motivation
- Fixes a specific bug,

# Testing

## Manual testing
- Creating push notifications using external_id value was tested.



# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.