### PR TITLE
feat: add Huawei and `email_reply_to_address` parameters to `Notification`

### DIFF
--- a/.github/workflows/npm_deploy.yml
+++ b/.github/workflows/npm_deploy.yml
@@ -36,4 +36,4 @@ jobs:
               -p @semantic-release/github \
               -p @semantic-release/npm \
               -p conventional-changelog-conventionalcommits \
-              semantic-release
+              semantic-release --dry-run

--- a/apis/DefaultApi.ts
+++ b/apis/DefaultApi.ts
@@ -85,7 +85,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -145,7 +145,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -224,7 +224,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -290,7 +290,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -349,7 +349,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -400,7 +400,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -459,7 +459,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -510,7 +510,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -564,7 +564,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -638,7 +638,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -689,7 +689,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -747,7 +747,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -822,7 +822,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -871,7 +871,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -920,7 +920,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -968,7 +968,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1016,7 +1016,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -1077,7 +1077,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1125,7 +1125,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -1173,7 +1173,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -1240,7 +1240,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1288,7 +1288,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1329,7 +1329,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1362,7 +1362,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1410,7 +1410,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -1463,7 +1463,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -1520,7 +1520,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -1596,7 +1596,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (outcomeNames !== undefined) {
@@ -1666,7 +1666,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (offset !== undefined) {
@@ -1732,7 +1732,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1781,7 +1781,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -1837,7 +1837,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -1903,7 +1903,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -1970,7 +1970,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (token !== undefined) {
@@ -2031,7 +2031,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2090,7 +2090,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2157,7 +2157,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2223,7 +2223,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2298,7 +2298,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2364,7 +2364,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -2443,7 +2443,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         // Body Params
@@ -2495,7 +2495,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -2543,7 +2543,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {
@@ -2594,7 +2594,7 @@ export class DefaultApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Always add the One Signal telemetry to the request.
-        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.3.1-beta1");
+        requestContext.setHeaderParam("OS-Usage-Data", "kind=sdk, sdk-name=onesignal-typescript, version=5.4.0-beta1");
 
         // Query Params
         if (appId !== undefined) {

--- a/models/BasicNotification.ts
+++ b/models/BasicNotification.ts
@@ -397,6 +397,10 @@ export class BasicNotification {
     */
     'email_from_address'?: string;
     /**
+    * Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address. 
+    */
+    'email_reply_to_address'?: string;
+    /**
     * Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null. 
     */
     'email_preheader'?: string;
@@ -421,6 +425,26 @@ export class BasicNotification {
     * Channel: All JSON object that can be used as a source of message personalization data for fields that support tag variable substitution. Push, SMS: Can accept up to 2048 bytes of valid JSON. Email: Can accept up to 10000 bytes of valid JSON. Example: {\"order_id\": 123, \"currency\": \"USD\", \"amount\": 25} 
     */
     'custom_data'?: object;
+    /**
+    * Channel: Push Notifications Platform: Huawei Full path of the app entry activity class
+    */
+    'huawei_badge_class'?: string;
+    /**
+    * Channel: Push Notifications Platform: Huawei Accumulative badge number, which is an integer ranging from 1 to 99
+    */
+    'huawei_badge_add_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Badge number, which is an integer ranging from 0 to 99
+    */
+    'huawei_badge_set_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Category of the push notification for HMS classification.
+    */
+    'huawei_category'?: BasicNotificationHuaweiCategoryEnum;
+    /**
+    * Channel: Push Notifications Platform: Huawei A tag used for Huawei business intelligence and analytics.
+    */
+    'huawei_bi_tag'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -1032,6 +1056,12 @@ export class BasicNotification {
             "format": ""
         },
         {
+            "name": "email_reply_to_address",
+            "baseName": "email_reply_to_address",
+            "type": "string",
+            "format": ""
+        },
+        {
             "name": "email_preheader",
             "baseName": "email_preheader",
             "type": "string",
@@ -1072,6 +1102,36 @@ export class BasicNotification {
             "baseName": "custom_data",
             "type": "object",
             "format": ""
+        },
+        {
+            "name": "huawei_badge_class",
+            "baseName": "huawei_badge_class",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_add_num",
+            "baseName": "huawei_badge_add_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_set_num",
+            "baseName": "huawei_badge_set_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_category",
+            "baseName": "huawei_category",
+            "type": "BasicNotificationHuaweiCategoryEnum",
+            "format": ""
+        },
+        {
+            "name": "huawei_bi_tag",
+            "baseName": "huawei_bi_tag",
+            "type": "string",
+            "format": ""
         }    ];
 
     static getAttributeTypeMap() {
@@ -1085,4 +1145,5 @@ export class BasicNotification {
 
 export type BasicNotificationTargetChannelEnum = "push" | "email" | "sms" ;
 export type BasicNotificationAggregationEnum = "sum" | "count" ;
+export type BasicNotificationHuaweiCategoryEnum = "IM" | "VOIP" | "SUBSCRIPTION" | "TRAVEL" | "HEALTH" | "WORK" | "ACCOUNT" | "EXPRESS" | "FINANCE" | "DEVICE_REMINDER" | "MAIL" | "MARKETING" ;
 

--- a/models/BasicNotificationAllOf.ts
+++ b/models/BasicNotificationAllOf.ts
@@ -346,6 +346,10 @@ export class BasicNotificationAllOf {
     */
     'email_from_address'?: string;
     /**
+    * Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address. 
+    */
+    'email_reply_to_address'?: string;
+    /**
     * Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null. 
     */
     'email_preheader'?: string;
@@ -370,6 +374,26 @@ export class BasicNotificationAllOf {
     * Channel: All JSON object that can be used as a source of message personalization data for fields that support tag variable substitution. Push, SMS: Can accept up to 2048 bytes of valid JSON. Email: Can accept up to 10000 bytes of valid JSON. Example: {\"order_id\": 123, \"currency\": \"USD\", \"amount\": 25} 
     */
     'custom_data'?: object;
+    /**
+    * Channel: Push Notifications Platform: Huawei Full path of the app entry activity class
+    */
+    'huawei_badge_class'?: string;
+    /**
+    * Channel: Push Notifications Platform: Huawei Accumulative badge number, which is an integer ranging from 1 to 99
+    */
+    'huawei_badge_add_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Badge number, which is an integer ranging from 0 to 99
+    */
+    'huawei_badge_set_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Category of the push notification for HMS classification.
+    */
+    'huawei_category'?: BasicNotificationAllOfHuaweiCategoryEnum;
+    /**
+    * Channel: Push Notifications Platform: Huawei A tag used for Huawei business intelligence and analytics.
+    */
+    'huawei_bi_tag'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -903,6 +927,12 @@ export class BasicNotificationAllOf {
             "format": ""
         },
         {
+            "name": "email_reply_to_address",
+            "baseName": "email_reply_to_address",
+            "type": "string",
+            "format": ""
+        },
+        {
             "name": "email_preheader",
             "baseName": "email_preheader",
             "type": "string",
@@ -943,6 +973,36 @@ export class BasicNotificationAllOf {
             "baseName": "custom_data",
             "type": "object",
             "format": ""
+        },
+        {
+            "name": "huawei_badge_class",
+            "baseName": "huawei_badge_class",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_add_num",
+            "baseName": "huawei_badge_add_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_set_num",
+            "baseName": "huawei_badge_set_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_category",
+            "baseName": "huawei_category",
+            "type": "BasicNotificationAllOfHuaweiCategoryEnum",
+            "format": ""
+        },
+        {
+            "name": "huawei_bi_tag",
+            "baseName": "huawei_bi_tag",
+            "type": "string",
+            "format": ""
         }    ];
 
     static getAttributeTypeMap() {
@@ -955,4 +1015,5 @@ export class BasicNotificationAllOf {
 
 
 export type BasicNotificationAllOfAggregationEnum = "sum" | "count" ;
+export type BasicNotificationAllOfHuaweiCategoryEnum = "IM" | "VOIP" | "SUBSCRIPTION" | "TRAVEL" | "HEALTH" | "WORK" | "ACCOUNT" | "EXPRESS" | "FINANCE" | "DEVICE_REMINDER" | "MAIL" | "MARKETING" ;
 

--- a/models/Notification.ts
+++ b/models/Notification.ts
@@ -397,6 +397,10 @@ export class Notification {
     */
     'email_from_address'?: string;
     /**
+    * Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address. 
+    */
+    'email_reply_to_address'?: string;
+    /**
     * Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null. 
     */
     'email_preheader'?: string;
@@ -421,6 +425,26 @@ export class Notification {
     * Channel: All JSON object that can be used as a source of message personalization data for fields that support tag variable substitution. Push, SMS: Can accept up to 2048 bytes of valid JSON. Email: Can accept up to 10000 bytes of valid JSON. Example: {\"order_id\": 123, \"currency\": \"USD\", \"amount\": 25} 
     */
     'custom_data'?: object;
+    /**
+    * Channel: Push Notifications Platform: Huawei Full path of the app entry activity class
+    */
+    'huawei_badge_class'?: string;
+    /**
+    * Channel: Push Notifications Platform: Huawei Accumulative badge number, which is an integer ranging from 1 to 99
+    */
+    'huawei_badge_add_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Badge number, which is an integer ranging from 0 to 99
+    */
+    'huawei_badge_set_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Category of the push notification for HMS classification.
+    */
+    'huawei_category'?: NotificationHuaweiCategoryEnum;
+    /**
+    * Channel: Push Notifications Platform: Huawei A tag used for Huawei business intelligence and analytics.
+    */
+    'huawei_bi_tag'?: string;
     /**
     * Channel: All Schedule notification for future delivery. API defaults to UTC -1100 Examples: All examples are the exact same date & time. \"Thu Sep 24 2015 14:00:00 GMT-0700 (PDT)\" \"September 24th 2015, 2:00:00 pm UTC-07:00\" \"2015-09-24 14:00:00 GMT-0700\" \"Sept 24 2015 14:00:00 GMT-0700\" \"Thu Sep 24 2015 14:00:00 GMT-0700 (Pacific Daylight Time)\" Note: SMS currently only supports send_after parameter. 
     */
@@ -1036,6 +1060,12 @@ export class Notification {
             "format": ""
         },
         {
+            "name": "email_reply_to_address",
+            "baseName": "email_reply_to_address",
+            "type": "string",
+            "format": ""
+        },
+        {
             "name": "email_preheader",
             "baseName": "email_preheader",
             "type": "string",
@@ -1078,6 +1108,36 @@ export class Notification {
             "format": ""
         },
         {
+            "name": "huawei_badge_class",
+            "baseName": "huawei_badge_class",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_add_num",
+            "baseName": "huawei_badge_add_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_set_num",
+            "baseName": "huawei_badge_set_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_category",
+            "baseName": "huawei_category",
+            "type": "NotificationHuaweiCategoryEnum",
+            "format": ""
+        },
+        {
+            "name": "huawei_bi_tag",
+            "baseName": "huawei_bi_tag",
+            "type": "string",
+            "format": ""
+        },
+        {
             "name": "send_after",
             "baseName": "send_after",
             "type": "string",
@@ -1095,4 +1155,5 @@ export class Notification {
 
 export type NotificationTargetChannelEnum = "push" | "email" | "sms" ;
 export type NotificationAggregationEnum = "sum" | "count" ;
+export type NotificationHuaweiCategoryEnum = "IM" | "VOIP" | "SUBSCRIPTION" | "TRAVEL" | "HEALTH" | "WORK" | "ACCOUNT" | "EXPRESS" | "FINANCE" | "DEVICE_REMINDER" | "MAIL" | "MARKETING" ;
 

--- a/models/NotificationWithMeta.ts
+++ b/models/NotificationWithMeta.ts
@@ -401,6 +401,10 @@ export class NotificationWithMeta {
     */
     'email_from_address'?: string;
     /**
+    * Channel: Email The email address where replies should be sent. If not specified, replies will go to the from address. 
+    */
+    'email_reply_to_address'?: string;
+    /**
     * Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null. 
     */
     'email_preheader'?: string;
@@ -425,6 +429,26 @@ export class NotificationWithMeta {
     * Channel: All JSON object that can be used as a source of message personalization data for fields that support tag variable substitution. Push, SMS: Can accept up to 2048 bytes of valid JSON. Email: Can accept up to 10000 bytes of valid JSON. Example: {\"order_id\": 123, \"currency\": \"USD\", \"amount\": 25} 
     */
     'custom_data'?: object;
+    /**
+    * Channel: Push Notifications Platform: Huawei Full path of the app entry activity class
+    */
+    'huawei_badge_class'?: string;
+    /**
+    * Channel: Push Notifications Platform: Huawei Accumulative badge number, which is an integer ranging from 1 to 99
+    */
+    'huawei_badge_add_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Badge number, which is an integer ranging from 0 to 99
+    */
+    'huawei_badge_set_num'?: number;
+    /**
+    * Channel: Push Notifications Platform: Huawei Category of the push notification for HMS classification.
+    */
+    'huawei_category'?: NotificationWithMetaHuaweiCategoryEnum;
+    /**
+    * Channel: Push Notifications Platform: Huawei A tag used for Huawei business intelligence and analytics.
+    */
+    'huawei_bi_tag'?: string;
     /**
     * Number of notifications that were successfully delivered.
     */
@@ -1078,6 +1102,12 @@ export class NotificationWithMeta {
             "format": ""
         },
         {
+            "name": "email_reply_to_address",
+            "baseName": "email_reply_to_address",
+            "type": "string",
+            "format": ""
+        },
+        {
             "name": "email_preheader",
             "baseName": "email_preheader",
             "type": "string",
@@ -1117,6 +1147,36 @@ export class NotificationWithMeta {
             "name": "custom_data",
             "baseName": "custom_data",
             "type": "object",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_class",
+            "baseName": "huawei_badge_class",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_add_num",
+            "baseName": "huawei_badge_add_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_badge_set_num",
+            "baseName": "huawei_badge_set_num",
+            "type": "number",
+            "format": ""
+        },
+        {
+            "name": "huawei_category",
+            "baseName": "huawei_category",
+            "type": "NotificationWithMetaHuaweiCategoryEnum",
+            "format": ""
+        },
+        {
+            "name": "huawei_bi_tag",
+            "baseName": "huawei_bi_tag",
+            "type": "string",
             "format": ""
         },
         {
@@ -1203,4 +1263,5 @@ export class NotificationWithMeta {
 
 export type NotificationWithMetaTargetChannelEnum = "push" | "email" | "sms" ;
 export type NotificationWithMetaAggregationEnum = "sum" | "count" ;
+export type NotificationWithMetaHuaweiCategoryEnum = "IM" | "VOIP" | "SUBSCRIPTION" | "TRAVEL" | "HEALTH" | "WORK" | "ACCOUNT" | "EXPRESS" | "FINANCE" | "DEVICE_REMINDER" | "MAIL" | "MARKETING" ;
 

--- a/models/ObjectSerializer.ts
+++ b/models/ObjectSerializer.ts
@@ -69,8 +69,8 @@ export * from './WebButton';
 import { ApiKeyToken    , ApiKeyTokenIpAllowlistModeEnum    } from './ApiKeyToken';
 import { ApiKeyTokensListResponse } from './ApiKeyTokensListResponse';
 import { App            , AppApnsEnvEnum                        } from './App';
-import { BasicNotification            , BasicNotificationTargetChannelEnum     , BasicNotificationAggregationEnum                                                                                              } from './BasicNotification';
-import { BasicNotificationAllOf   , BasicNotificationAllOfAggregationEnum                                                                                              } from './BasicNotificationAllOf';
+import { BasicNotification            , BasicNotificationTargetChannelEnum     , BasicNotificationAggregationEnum                                                                                                 , BasicNotificationHuaweiCategoryEnum    } from './BasicNotification';
+import { BasicNotificationAllOf   , BasicNotificationAllOfAggregationEnum                                                                                                 , BasicNotificationAllOfHuaweiCategoryEnum    } from './BasicNotificationAllOf';
 import { BasicNotificationAllOfAndroidBackgroundLayout } from './BasicNotificationAllOfAndroidBackgroundLayout';
 import { Button } from './Button';
 import { CopyTemplateRequest } from './CopyTemplateRequest';
@@ -96,12 +96,12 @@ import { GenericSuccessBoolResponse } from './GenericSuccessBoolResponse';
 import { GetNotificationHistoryRequestBody, GetNotificationHistoryRequestBodyEventsEnum     } from './GetNotificationHistoryRequestBody';
 import { GetSegmentsSuccessResponse } from './GetSegmentsSuccessResponse';
 import { LanguageStringMap } from './LanguageStringMap';
-import { Notification            , NotificationTargetChannelEnum     , NotificationAggregationEnum                                                                                               } from './Notification';
+import { Notification            , NotificationTargetChannelEnum     , NotificationAggregationEnum                                                                                                 , NotificationHuaweiCategoryEnum     } from './Notification';
 import { NotificationAllOf } from './NotificationAllOf';
 import { NotificationHistorySuccessResponse } from './NotificationHistorySuccessResponse';
 import { NotificationSlice } from './NotificationSlice';
 import { NotificationTarget            , NotificationTargetTargetChannelEnum   } from './NotificationTarget';
-import { NotificationWithMeta            , NotificationWithMetaTargetChannelEnum     , NotificationWithMetaAggregationEnum                                                                                                          } from './NotificationWithMeta';
+import { NotificationWithMeta            , NotificationWithMetaTargetChannelEnum     , NotificationWithMetaAggregationEnum                                                                                                 , NotificationWithMetaHuaweiCategoryEnum                } from './NotificationWithMeta';
 import { NotificationWithMetaAllOf } from './NotificationWithMetaAllOf';
 import { Operator, OperatorOperatorEnum   } from './Operator';
 import { OutcomeData  , OutcomeDataAggregationEnum   } from './OutcomeData';
@@ -158,7 +158,9 @@ let enumsMap: Set<string> = new Set<string>([
     "AppApnsEnvEnum",
     "BasicNotificationTargetChannelEnum",
     "BasicNotificationAggregationEnum",
+    "BasicNotificationHuaweiCategoryEnum",
     "BasicNotificationAllOfAggregationEnum",
+    "BasicNotificationAllOfHuaweiCategoryEnum",
     "CreateApiKeyRequestIpAllowlistModeEnum",
     "FilterRelationEnum",
     "FilterExpressionRelationEnum",
@@ -166,9 +168,11 @@ let enumsMap: Set<string> = new Set<string>([
     "GetNotificationHistoryRequestBodyEventsEnum",
     "NotificationTargetChannelEnum",
     "NotificationAggregationEnum",
+    "NotificationHuaweiCategoryEnum",
     "NotificationTargetTargetChannelEnum",
     "NotificationWithMetaTargetChannelEnum",
     "NotificationWithMetaAggregationEnum",
+    "NotificationWithMetaHuaweiCategoryEnum",
     "OperatorOperatorEnum",
     "OutcomeDataAggregationEnum",
     "StartLiveActivityRequestEventEnum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onesignal/node-onesignal",
-  "version": "5.3.1-beta1",
+  "version": "5.4.0-beta1",
   "description": "OpenAPI client for @onesignal/node-onesignal",
   "author": "OpenAPI-Generator Contributors",
   "keywords": [


### PR DESCRIPTION
## Features

Adds the following `Notification` parameters:
- `huawei_badge_class`
- `huawei_badge_add_num`
- `huawei_badge_set_num`
- `huawei_category`
- `huawei_bi_tag`
- `email_reply_to_address`