### PR TITLE
chore: add a `repository` field to package.json for npm's provenance verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Publish to NPM and Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx -p semantic-release \
               -p @semantic-release/changelog \

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/OneSignal/onesignal-node-api",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OneSignal/onesignal-node-api"
+  },
   "main": "./dist/index.js",
   "type": "commonjs",
   "exports": {


### PR DESCRIPTION
## Updates

- add a `repository` field to package.json for npm's provenance verification