### PR TITLE
Add v5.5.0 package updates

### DIFF
--- a/DefaultApi.md
+++ b/DefaultApi.md
@@ -540,12 +540,15 @@ const configuration = Onesignal.createConfiguration({
 });
 const apiInstance = new Onesignal.DefaultApi(configuration);
 
-let body: Onesignal.DefaultApiCreateNotificationRequest = {
-  // Notification
-  notification: null,
-};
+const notification = new Onesignal.Notification();
+notification.app_id = 'YOUR_APP_ID';
+notification.contents = { en: 'Hello from OneSignal!' };
+notification.headings = { en: 'Push Notification' };
+// Target by External ID: alias keys must match the API (external_id, not externalId).
+notification.include_aliases = { external_id: ['YOUR_USER_EXTERNAL_ID'] };
+notification.target_channel = 'push';
 
-const response = await apiInstance.createNotification(body);
+const response = await apiInstance.createNotification(notification);
 console.log(response);
 ```
 


### PR DESCRIPTION
## Release v5.5.0

### 🚀 Features
- feat(ci): close stale user-api-updates PRs before fan-out
- feat: add flat create-notification doc examples via vendor extension

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(ci): tolerate gh pr close failures during stale PR cleanup
- fix: Rust consumer imports, Python model imports, Java modelPackage in API docs
- fix(ci): drift-mode rerun safety + pre-release range matching

### 📚 Docs
- docs: point partial-release caveat at SDK-4396 (cd.yml scope filter)

### 🔧 Internal
- build(release): bump package versions
- test(ruby): use string outer / symbol inner keys for result.content
- build(ruby): sync release workflow fix
- ci: generate real release notes in downstream PR bodies
- ci: correct release-notes anchor + warn on compareCommits truncation
- ci: add script/bump-version helper
- ci: auto-populate root release PR body via sdk-shared/create-release.yml
- ci: add one-click release orchestrator via sdk-shared/prep-release.yml
- ci: unstage devdist's pre-staged outputs deletions before chore commit
- ci: delegate release version math to node-semver CLI
- ci: enforce lockstep versioning across all client libraries
- ci: add partial-release label bypass + document per-language hotfix flow
- ci: gate release workflow on script/test-<lang> matrix
- ci: pin release test matrix checkouts to rel/<version>
- ci: cut root GitHub Release on every release PR merge
- ci: anchor downstream-links version on commit message, not api.json
- ci: harden downstream-links gate, reconcile bare-version tags, make re-runs idempotent
- ci: auto-transition Linear tickets to Deployed on release
- ci: tighten lint-pr-title.yml to align with sdk-shared conventions
- ci: scope cd.yml fan-out to changed outputs/<lang>/ trees
- ci: address PR #364 review feedback
- ci: support drift-preserving releases (per-library version bumps)
- build: sync generated SDKs and DefaultApi reference docs
- build: refresh DefaultApi.md for Java, Python, and Rust

---
_Generated from [OneSignal/api-client-libraries@bc71af6...8a77f63](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...8a77f63491b3d6c70b21ab49e189efca93ed6833)._