### PR TITLE
docs: add flat create-notification doc examples

### DIFF
--- a/DefaultApi.md
+++ b/DefaultApi.md
@@ -540,12 +540,15 @@ const configuration = Onesignal.createConfiguration({
 });
 const apiInstance = new Onesignal.DefaultApi(configuration);
 
-let body: Onesignal.DefaultApiCreateNotificationRequest = {
-  // Notification
-  notification: null,
-};
+const notification = new Onesignal.Notification();
+notification.app_id = 'YOUR_APP_ID';
+notification.contents = { en: 'Hello from OneSignal!' };
+notification.headings = { en: 'Push Notification' };
+// Target by External ID: alias keys must match the API (external_id, not externalId).
+notification.include_aliases = { external_id: ['YOUR_USER_EXTERNAL_ID'] };
+notification.target_channel = 'push';
 
-const response = await apiInstance.createNotification(body);
+const response = await apiInstance.createNotification(notification);
 console.log(response);
 ```
 


### PR DESCRIPTION
## Updates
- docs: add flat create-notification doc examples

---
_Generated from [OneSignal/api-client-libraries@bc71af6...35a92b9](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...35a92b9872393d79d8270897b2e134f2b42562b0)._